### PR TITLE
Mise à jour SQLFluff (de 2.3.5 à 3.2.0)

### DIFF
--- a/sqlfluff-bigquery/.pre-commit-config.yaml
+++ b/sqlfluff-bigquery/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/sqlfluff/sqlfluff
-  rev: 2.3.5
+  rev: 3.2.0
   hooks:
     - id: sqlfluff-lint
       # For dbt projects, this installs the dbt "extras".


### PR DESCRIPTION
SQLfluff a corrigé le problème de linting avec le group by all de BigQuery et donc il faut mettre à jour la version (en espérant que ça ne crée pas d'autres problèmes 🤞 )